### PR TITLE
python-maturin: update to 1.2.3

### DIFF
--- a/abi_used_symbols
+++ b/abi_used_symbols
@@ -43,7 +43,6 @@ libc.so.6:memmove
 libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
-libc.so.6:mmap
 libc.so.6:mmap64
 libc.so.6:mprotect
 libc.so.6:munmap

--- a/package.yml
+++ b/package.yml
@@ -1,11 +1,12 @@
 name       : python-maturin
-version    : 1.1.0
-release    : 35
+version    : 1.2.3
+release    : 36
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.1.0.tar.gz : 57b990348a9182897d64e7bc2b7be6e323912500c10a56174090fa8008173ad0
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.2.3.tar.gz : 61e119a3d9b8f8083b7765236bc52afe779a0c2ae8c3aebc9e52d36560733772
 license    :
     - Apache-2.0
     - MIT
+homepage   : https://www.maturin.rs/
 component  : programming.python
 networking : yes
 summary    : Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>python-maturin</Name>
+        <Homepage>https://www.maturin.rs/</Homepage>
         <Packager>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
@@ -21,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.1.0-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.1.0-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.1.0-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.1.0-py3.10.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.1.0-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.1.0-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__pycache__/__init__.cpython-310.pyc</Path>
@@ -36,9 +37,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2023-06-10</Date>
-            <Version>1.1.0</Version>
+        <Update release="36">
+            <Date>2023-09-17</Date>
+            <Version>1.2.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Changes:**
- Fix crashing on unknown platforms
- Warn about incompatible targets for musllinux
- Add Linux mips64, mips architecture support
- Remove `__init__.py` requirement
- Add support for `x86_64h-apple-darwin` target
- Add non-interactive mode to `upload` command
- Fix `link-native-libraries` check for emscripten target
- Support `ALL_PROXY` in upload
- Handle renamed Rust dependency in sdist
- Query default macOS deployment target from `rustc --print deployment-target`
- Fix invalid TOML when rewriting workspace inherited dependencies
- Fix non interactive mode check when username/password was supplied from cli
- Fix: preserve workspace inherited dependencies when building binary

**Test Plan:**
- Built `python-orjson`

### Checklist

- [x] Package was built and tested against unstable
